### PR TITLE
feat: ユーザー新規登録画面を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,8 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import Register from './Register'
 
 function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+  return <Register />
 }
 
 export default App

--- a/src/Register.css
+++ b/src/Register.css
@@ -1,0 +1,22 @@
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 300px;
+  margin: 2rem auto;
+}
+
+.form-container label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.form-container button {
+  padding: 0.5rem;
+}
+
+.error {
+  color: red;
+  font-size: 0.9rem;
+}

--- a/src/Register.tsx
+++ b/src/Register.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+import './Register.css'
+
+interface FormData {
+  username: string
+  email: string
+  password: string
+  confirmPassword: string
+}
+
+export default function Register() {
+  const [formData, setFormData] = useState<FormData>({
+    username: '',
+    email: '',
+    password: '',
+    confirmPassword: '',
+  })
+
+  const [error, setError] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (formData.password !== formData.confirmPassword) {
+      setError('パスワードが一致しません')
+      return
+    }
+    setError('')
+    console.log('Registered:', formData)
+  }
+
+  return (
+    <form className="form-container" onSubmit={handleSubmit}>
+      <h2>新規登録</h2>
+      <label>
+        ユーザー名
+        <input
+          type="text"
+          name="username"
+          value={formData.username}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        メールアドレス
+        <input
+          type="email"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        パスワード
+        <input
+          type="password"
+          name="password"
+          value={formData.password}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        パスワード（確認）
+        <input
+          type="password"
+          name="confirmPassword"
+          value={formData.confirmPassword}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      {error && <p className="error">{error}</p>}
+      <button type="submit">登録</button>
+    </form>
+  )
+}


### PR DESCRIPTION
## 概要
- 登録フォームにパスワード確認入力を追加し、一致チェックを実装
- エラーメッセージ表示用のスタイルを追加

## テスト
- `npm test` (スクリプト未定義のため失敗)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9227e82bc83268765933b882ea492