### PR TITLE
パスワードの条件チェックを追加

### DIFF
--- a/src/Register.tsx
+++ b/src/Register.tsx
@@ -57,6 +57,23 @@ export default function Register() {
       setError('パスワードが一致しません')
       return
     }
+
+    if (formData.password.length < 8) {
+      setError('パスワードは8文字以上にしてください')
+      return
+    }
+
+    if (!/[A-Za-z]/.test(formData.password) || !/\d/.test(formData.password)) {
+      setError('パスワードは英字と数字を含めてください')
+      return
+    }
+
+    const birthDigits = formData.birthdate.replace(/-/g, '')
+    if (birthDigits && formData.password.includes(birthDigits)) {
+      setError('パスワードに生年月日を含めないでください')
+      return
+    }
+
     setError('')
     console.log('Registered:', formData)
   }


### PR DESCRIPTION
## 概要
- パスワードの長さ・英数字混在・生年月日の連番をチェックするバリデーションを追加

## テスト
- `npm test` (スクリプト未定義のため失敗)
- `npm run lint`
- `npm run build` (型定義が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b929483bd88326822fe3aca12dd6d0